### PR TITLE
Add current streak support to Wordle stats

### DIFF
--- a/app/app.py
+++ b/app/app.py
@@ -199,6 +199,7 @@ def api_wordle_stats():
         wins_in_5 = int(query.get(b"wins-5").strip())
         wins_in_6 = int(query.get(b"wins-6").strip())
         losses = int(query.get(b"losses").strip())
+        current_streak = int(query.get(b"current-streak").strip())
         max_streak = int(query.get(b"max-streak").strip())
         wins_total = sum(
             [wins_in_1, wins_in_2, wins_in_3, wins_in_4, wins_in_5, wins_in_6]
@@ -229,7 +230,7 @@ def api_wordle_stats():
     if failed:
         return redirect("https://www.nytimes.com/games/wordle")
     return redirect(
-        f"https://www.nytimes.com/games/wordle?data={{%22time%22:{int(time.time() - (5 * 60))},%22statistics%22:{{%22currentStreak%22:0,%22maxStreak%22:{max_streak},%22guesses%22:{{%221%22:{wins_in_1},%222%22:{wins_in_2},%223%22:{wins_in_3},%224%22:{wins_in_4},%225%22:{wins_in_5},%226%22:{wins_in_6},%22fail%22:{losses}}},%22gamesPlayed%22:{games_played},%22gamesWon%22:{wins_total},%22averageGuesses%22:{average_guesses},%22winPercentage%22:{win_percentage}}},%22darkTheme%22:false,%22colorBlindTheme%22:null}}",
+        f"https://www.nytimes.com/games/wordle/index.html?data={{%22time%22:{int(time.time() - (5 * 60))},%22statistics%22:{{%22currentStreak%22:{current_streak},%22maxStreak%22:{max_streak},%22guesses%22:{{%221%22:{wins_in_1},%222%22:{wins_in_2},%223%22:{wins_in_3},%224%22:{wins_in_4},%225%22:{wins_in_5},%226%22:{wins_in_6},%22fail%22:{losses}}},%22gamesPlayed%22:{games_played},%22gamesWon%22:{wins_total},%22averageGuesses%22:{average_guesses},%22winPercentage%22:{win_percentage}}},%22darkTheme%22:false,%22colorBlindTheme%22:null}}",
         code=307,
     )
 

--- a/app/markdown/2022-02-17/wordle-stats.md
+++ b/app/markdown/2022-02-17/wordle-stats.md
@@ -28,6 +28,8 @@ Both my partner and I have lost our Wordle stats in the past and it can feel dem
   <input class="number-inputs" type="number" id="wins-6" name="wins-6" min="0" max="1000" value="0"><br>
   <label class="number-inputs" for="losses">Losses</label>
   <input class="number-inputs" type="number" id="losses" name="losses" min="0" max="1000" value="0"><br>
+  <label class="number-inputs" for="current-streak">Current Streak</label>
+  <input class="number-inputs" type="number" id="current-streak" name="current-streak" min="0" max="1000" value="0"><br>
   <label class="number-inputs" for="max-streak">Max Streak</label>
   <input class="number-inputs" type="number" id="max-streak" name="max-streak" min="0" max="1000" value="0"><br>
   <label class="number-inputs" for="games-played">Games Played</label>
@@ -83,28 +85,6 @@ If you were able to move or recover your stats and want to send some appreciatio
 ### What if I lost my statistics and don't remember them?
 
 Unfortunately they can't be recovered once lost, my recommendation is try remembering the number of wins in 1, 2, or 3 guesses and then keep playing. In the end, **Wordle is about having fun** and it'll keep being the same amazing game whether you have your old statistics or not.
-
-### Why can't I import my "Current Streak"?
-
-I'm not sure it's possible anymore? From looking at the below code I don't know how to get the field `nyt-wordle-state.lastPlayedTs` set. If you can figure it out please let me know!
-
-```js
-var e = new Proxy(new URLSearchParams(window.location.search), {
-    get: function(e, a) {
-        return e.get(a)
-    }
-});
-if (e.data) ! function(e) {
-    if (!e.statistics) throw new Error("User local data does not contain statistics. Aborting transfer.");
-    if (ns(e.statistics, e.force)) {
-        ts.setItem(ss, JSON.stringify(e.statistics));
-        var a = e.darkTheme;
-        window.themeManager.setDarkTheme(a);
-        var s = !!e.colorBlindTheme;
-        window.themeManager.setColorBlindTheme(s)
-    }
-}(JSON.parse(e.data))
-```
 
 ### Does this tool work with Quordle / Heardle / wordlegame.org / other Wordle clone?
 


### PR DESCRIPTION
It appears `currentStreak` can now be imported from the URL. Maybe some sort of bug fix from The New York Times?

Example URL: https://www.nytimes.com/games/wordle/index.html?data={%22time%22:1652500870,%22statistics%22:{%22currentStreak%22:43,%22maxStreak%22:10,%22guesses%22:{%221%22:10,%222%22:10,%223%22:10,%224%22:10,%225%22:10,%226%22:10,%22fail%22:10},%22gamesPlayed%22:70,%22gamesWon%22:60,%22averageGuesses%22:3,%22winPercentage%22:85},%22darkTheme%22:false,%22colorBlindTheme%22:null}

Note `%22currentStreak%22:43` in the URL. This URL will make the statistics look like this:

![image](https://user-images.githubusercontent.com/109995/168410658-21414580-b87d-4479-810c-41e707da5606.png)
