### PR TITLE
fix: update default branch reference in link

### DIFF
--- a/app/templates/links.html
+++ b/app/templates/links.html
@@ -10,7 +10,7 @@
 <p>
     Additionally, I share all the
     <a href="https://raw.githubusercontent.com/sethmlarson/sethmlarson.dev/refs/heads/main/archive/feeds.opml">RSS feeds</a>
-    I follow and <a href="https://raw.githubusercontent.com/sethmlarson/sethmlarson.dev/refs/heads/master/archive/articles.opml">article URLs</a>
+    I follow and <a href="https://raw.githubusercontent.com/sethmlarson/sethmlarson.dev/refs/heads/main/archive/articles.opml">article URLs</a>
     below using <a href="https://en.wikipedia.org/wiki/OPML">OPML</a>, an open standard for sharing groups of links with text and other metadata.
     You can import the feeds directly into your reader app of choice.
 </p>


### PR DESCRIPTION
Hi! I love your Blogrolls and Reblogs page, and while checking the RSS feed, I came across a broken link 😄